### PR TITLE
Be distro aware

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,8 @@
 ---
 - include: users.yml
   sudo: yes
-  tags:
-  - ec2
-  - virtualbox
-  - vsphere
 - include: ssh.yml
   sudo: yes
-  tags:
-  - ec2
-  - virtualbox
-  - vsphere
 - include: virtualbox.yml
   when: (ansible_virtualization_type == "virtualbox") and (ansible_virtualization_role == "guest")
   sudo: yes


### PR DESCRIPTION
Add distro checks before execution. Clean up some playbook tags.
## Motivation and Context

This role should check to make sure it's on a supported distro before doing stuff. Otherwise there is a real potential to blow up targets.
https://github.com/OULibraries/ansible-role-users/issues/6
## How Has This Been Tested?

ran against unsupported distros and watched nothing happen
ran against supported distros and watched previous behavior occur.
