### PR TITLE
Group users into standard and admin types and apply groups at that level

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 OULibraries.centos7
 =========
 
-This role adds users and makes changes to ssh config and sudoers config.
-
-Note: on Ubuntu, this sets wheel to be the sudoers group instead of sudo. Set your expectations accordingly.
+This role adds users wish ssh keys, and makes changes to ssh config and sudoers config.
 
 Requirements
 ------------
 
-A target system running CentOS/RHEL or Ubuntu 
+A target system running CentOS/RHEL. 
 
 Role Variables
 --------------
@@ -81,9 +79,8 @@ Match User centos Address 192.168.1.*
 
 Dependencies
 ------------
+No special dependencies. 
 
-Example Playbook
-----------------
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ OULibraries.centos7
 
 This role adds users and makes changes to ssh config and sudoers config.
 
-Note that on Ubuntu, this sets wheel to be the sudoers group instead of sudo. Set your expectations accordingly.
+Note: on Ubuntu, this sets wheel to be the sudoers group instead of sudo. Set your expectations accordingly.
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 OULibraries.centos7
 =========
 
-User management role for OULib. This role makes changes to ssh config and sudoers config.
-Note that on Ubuntu, this sets wheel to be the sudoers group instead of sudo.
-Set your expectations accordingly.
+This role adds users and makes changes to ssh config and sudoers config.
+
+Note that on Ubuntu, this sets wheel to be the sudoers group instead of sudo. Set your expectations accordingly.
 
 Requirements
 ------------
@@ -13,19 +13,37 @@ A target system running CentOS/RHEL or Ubuntu
 Role Variables
 --------------
 
-You'll need to define one or more users in the 'users' var. eg.
+### User Config
+
+
+Define users and the groups they should get as follows:
 
 ```
-users:
-  - name: 'centos'
-    groups: 'wheel'
-    pubkey: 'ssh-rsa somepubkey centos@example.org'
-  - name: 'centos1'
-    groups: 'wheel'
-    pubkey: 'ssh-rsa anotherpubkey centos@example.org'
+# Admin users (wheel membership is automatic)
+users_admin_groups: "tomcat,apache"
+users_admin_users:
+  - name: 'admin'
+    pubkey: 'ssh-rsa somepubkey admin@example.org'
+  - name: 'otheradmin'
+    pubkey: 'ssh-rsa anotherpubkey otheradmin@example.org'
+
+
+# Normal users 
+users_std_groups: apache
+users_std_users:
+  - name: 'tester'
+    pubkey: 'ssh-rsa somepubkey tester@example.org'
 ```
 
-You'll also need to define one or more ssh brokers in the 'ssh_brokers' var, eg.
+You may optionally define users_secure_path to allow sudo to work as expected with executables in arbitrary locations, eg.
+
+```
+users_secure_path: '/opt/somevendor/someproduct/bin:/sbin:/bin:/usr/sbin:/usr/bin'
+```
+
+### SSH Config
+
+To enable outgoing ssh, you'll need to define one or more ssh brokers in the 'ssh_brokers' var, eg.
 Note that dn suffix is the domain name space for the servers you will reach through the broker.
 
 ```
@@ -60,11 +78,6 @@ Match User centos Address 192.168.1.*
   MaxAuthTries 10
 ```
 
-You may optionally define users_secure_path to allow sudo to work as expected with executables in arbitrary locations, eg.
-
-```
-users_secure_path: '/opt/somevendor/someproduct/bin:/sbin:/bin:/usr/sbin:/usr/bin'
-```
 
 Dependencies
 ------------
@@ -80,4 +93,5 @@ License
 Author Information
 ------------------
 
-Jason Sherman
+OU Libraries
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 OULibraries.centos7
 =========
 
-This role adds users wish ssh keys, and makes changes to ssh config and sudoers config.
+This role adds users and ssh keys, confiures ssh, and configures sudoers.
 
 Requirements
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,12 @@
 ---
-
 users_secure_path: '/opt/oulib/users/bin:/sbin:/bin:/usr/sbin:/usr/bin'
+
+# wheel is implied
+users_admin_groups: ""
+users_admin_users: []
+
+users_std_groups: ""
+users_std_users: []
 
 sshd_denyusers:
   - vagrant

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -26,3 +26,12 @@
   with_items:
     - printusers.sh
     - printsecurepath.sh
+
+- name: Copy sudoers
+  template:
+    src: sudoers.j2
+    dest: /etc/sudoers
+    mode: 0400
+    owner: root
+    group: root
+    validate: 'visudo -cf %s'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,14 +20,14 @@
   tags:
   - users_virtualbox
 
-# Restart ssh service    
-- include: services.yml
-  become: true
-  tags:
-  - users_services
-
 # Install support scripts and other files    
 - include: assets.yml
   become: true
   tags:
   - users_assets
+
+# Restart ssh service
+- include: services.yml
+  become: true
+  tags:
+  - users_services

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,23 +1,32 @@
 ---
+
+# Provision user accounts and ssh keys
 - include: users.yml
   become: true
   tags:
   - users_users
+
+# Configure sshd and ssh defaults
 - include: ssh.yml
   become: true
   tags:
   - users_ssh
+
+# Configure Vagrant specific settings
 - include: virtualbox.yml
-  when: (ansible_virtualization_type == "virtualbox") and (ansible_virtualization_role == "guest")
+  when: (ansible_virtualization_type == "virtualbox") 
+          and (ansible_virtualization_role == "guest")
   become: true
   tags:
   - users_virtualbox
 
+# Restart ssh service    
 - include: services.yml
   become: true
   tags:
   - users_services
 
+# Install support scripts and other files    
 - include: assets.yml
   become: true
   tags:

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,24 +1,38 @@
 ---
+# We will use the wheel group to determine sudoers
 - name: group 'wheel' exists
   group:
     name: wheel
     state: present
     system: yes
-- name: user exists
-  user: name={{ item.name }} shell={{ item.shell|default('/bin/bash') }} groups={{ item.groups }} append=yes
-  with_items: "{{ users }}"
+
+- name: admin users exists
+  user:
+    name: "{{ item.name }}"
+    groups: "wheel,{{ users_admin_groups }}"
+    append: yes
+  with_items: "{{ users_admin_users }}"
+
 - name: ssh keys
   authorized_key:
     user: "{{ item.name }}"
     key: "{{ item.pubkey }}"
     state: present
     exclusive: yes
-  with_items: "{{ users }}"
-- name: Copy sudoers
-  template:
-    src: sudoers.j2
-    dest: /etc/sudoers
-    mode: 0400
-    owner: root
-    group: root
-    validate: 'visudo -cf %s'
+  with_items: "{{ users_admin_users }}"
+
+- name: standard users exists
+  user:
+    name: "{{ item.name }}"
+    groups: "{{ users_std_groups }}"
+    append: yes
+  with_items: "{{ users_std_users }}"
+
+- name: standard users ssh keys
+  authorized_key:
+    user: "{{ item.name }}"
+    key: "{{ item.pubkey }}"
+    state: present
+    exclusive: yes
+  with_items: "{{ users_std_users }}"
+

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -29,9 +29,6 @@ ChallengeResponseAuthentication no
 PermitRootLogin no
 DenyUsers {% for user in sshd_denyusers %} {{ user }}{% endfor %}
 
-#AllowUsers{% for user in users %} {{ user.name }}{% endfor %}
-
-
 # GSSAPI options
 GSSAPIAuthentication yes
 GSSAPICleanupCredentials no


### PR DESCRIPTION
This change  reorganizes the management of users in to standard and admin user types and applies group membership at that level.

* Standard users are configured by `users_std_groups` and `users_std_users`. 
* Admin users are configured with `users_admin_groups` and `users_admin_users`. 

Most role variables are now standardized with `users_` prefix, but ssh configuration variables have been left as-is pending possible future splitting of this role. 

Motivation and Context
----------------------

This removes the need for per-user configuration of group membership while still allowing for non-privileged, non-wheel users. Two levels of access per vm cover our current requirements and, and further specificity can be managed in ad-hoc playbooks should edge cases arise. 

How Has This Been Tested?
-------------------------
Tested in vagrant. Could use further testing during review. 
