### PR TITLE
Add extra config block to sudoers template.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,5 +8,7 @@ users_admin_users: []
 users_std_groups: ""
 users_std_users: []
 
+users_sudoers_extra: ""
+
 sshd_denyusers:
   - vagrant

--- a/templates/sudoers.j2
+++ b/templates/sudoers.j2
@@ -40,5 +40,11 @@ root    ALL=(ALL)       ALL
 ## Allows people in group wheel to run all commands without a password
 %wheel        ALL=(ALL)       NOPASSWD: ALL
 
+{% if users_sudoers_extra %}
+# Additional sudoers config defined by OULibraries.users role in
+# users_sudo_extra variable.
+{{ users_sudoers_extra }}
+
+{% endif %}
 ## Include files located in /etc/sudoers.d. (the # here does not mean a comment)
 #includedir /etc/sudoers.d

--- a/templates/sudoers.j2
+++ b/templates/sudoers.j2
@@ -40,11 +40,9 @@ root    ALL=(ALL)       ALL
 ## Allows people in group wheel to run all commands without a password
 %wheel        ALL=(ALL)       NOPASSWD: ALL
 
-{% if users_sudoers_extra %}
 # Additional sudoers config defined by OULibraries.users role in
-# users_sudo_extra variable.
+# users_sudoers_extra variable. 
 {{ users_sudoers_extra }}
 
-{% endif %}
 ## Include files located in /etc/sudoers.d. (the # here does not mean a comment)
 #includedir /etc/sudoers.d


### PR DESCRIPTION
Adds the variable `users_sudoers_extra`, intended to contain a block of config to be inserted in the `/etc/suoders`. 

Motivation and Context
----------------------
We need a straightforward way of addressing some ad hoc sudo config needed in the short term. 

How Has This Been Tested?
-------------------------
Manually tested in vagrant,
