### PR TITLE
Add /usr/local/bin to secure path variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-OULibraries.centos7
+OULibraries.users
 =========
 
 This role adds users and ssh keys, confiures ssh, and configures sudoers.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-users_secure_path: '/opt/oulib/users/bin:/sbin:/bin:/usr/sbin:/usr/bin'
+users_secure_path: '/opt/oulib/users/bin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin'
 
 # wheel is implied
 users_admin_groups: ""


### PR DESCRIPTION
<!--- Replace this with the title of your PR, or specify the title above and delete this line-->
Add `/usr/local/bin` to `users_secure_path` variable
<!--- Replace this with a detailed description of your changes -->
Simple change to add the `/usr/local/bin` path to the `users_secure_path` variable.
Motivation and Context
----------------------
<!--- Why is this change required? What problem does it solve? -->
This change makes binaries (at this point, mainly `aws` and `aws_completer`) available to users. Mainly this will allow playbooks or other tools that use `sudo` to access these binaries without having to provide the absolute path.
<!--- If it relates to an open issue or another pull request, please link to that here. -->

How Has This Been Tested?
-------------------------
This change has been tested against the `ojs-upgrade` box.
